### PR TITLE
Declare PHP class variables to fix PHP 8.2 deprecated message

### DIFF
--- a/includes/class-clickship-shipping.php
+++ b/includes/class-clickship-shipping.php
@@ -41,6 +41,34 @@ if ( ! class_exists( 'WC_Clickship_Shipping_Rates_Method' ) ) {
 	 */
 	protected $filters;
 
+	
+	/**
+     * The URL associated with the ClickShip service.
+     *
+     * @since    1.0.0
+     * @access   protected
+     * @var      string   $clickship_url    The URL for the ClickShip service.
+     */
+	protected $clickship_url;
+	
+	/**
+     * The identifier for the specific marketplace integrated with the plugin.
+     *
+     * @since    1.0.0
+     * @access   protected
+     * @var      string   $marketplace_id    The ID or code for the integrated marketplace.
+     */
+	protected $marketplace_id;
+	
+	/**
+     * Flag to enable or disable the ClickShip integration within the plugin.
+     *
+     * @since    1.0.0
+     * @access   protected
+     * @var      bool     $clickship_enable    Flag to enable or disable ClickShip functionality.
+     */
+	protected $clickship_enable;
+
 	/**
 	 * Initialize the collections used to maintain the actions and filters.
 	 *


### PR DESCRIPTION
**Pull Request: Adding Descriptive Comments for Class Variables**

This pull request addresses the deprecated message related to PHP 8.2 and introduces clear and informative variable descriptions within the codebase.

**Changes Made:**
- Added descriptive comments for class variables, specifically `$clickship_url`, `$marketplace_id`, and `$clickship_enable`.
- Enhanced code readability and maintainability by documenting the purpose and usage of these variables.

**Why these changes are necessary:**
- The PHP 8.2 deprecated message needed to be resolved for the codebase to remain compatible with the latest PHP version.
- Descriptive comments for class variables aid in understanding the codebase, making it easier for developers to work with and maintain.

This change does not introduce functional alterations to the code but serves to enhance code quality and compliance with PHP 8.2.

**Testing:**
- No functional changes were made; thus, existing tests and functionality should remain unaffected.

Please review and merge this pull request to ensure code compatibility and maintainability. Thank you!